### PR TITLE
added custom code executor

### DIFF
--- a/GoNativeIOS.xcodeproj/project.pbxproj
+++ b/GoNativeIOS.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		20FC7FB5199D1C7800A70B08 /* LEANTabManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 20FC7FB4199D1C7800A70B08 /* LEANTabManager.m */; };
 		37603BBC19BAB5D18A6D3869 /* Pods_OneSignalNotificationServiceExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E14A3DDFB9CBC01A6B4DD895 /* Pods_OneSignalNotificationServiceExtension.framework */; };
 		8F8E3DF28CCE41C11B42815F /* Pods_GonativeIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E719C7B8DD8E912B06801D6 /* Pods_GonativeIO.framework */; };
+		A02BE0AB266E21BD00B3CF50 /* LEANJsCustomCodeExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = A02BE0AA266E21BD00B3CF50 /* LEANJsCustomCodeExecutor.m */; };
 		BB9A3B012631D2A7002C38F1 /* LEANIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9A3B002631D2A7002C38F1 /* LEANIcons.swift */; };
 /* End PBXBuildFile section */
 
@@ -302,6 +303,8 @@
 		2AA9195813550BD85883FBBE /* Pods-GonativeIO.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GonativeIO.debug.xcconfig"; path = "Target Support Files/Pods-GonativeIO/Pods-GonativeIO.debug.xcconfig"; sourceTree = "<group>"; };
 		95A160ACACAE73AB3E15EAD9 /* Pods-OneSignalNotificationServiceExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OneSignalNotificationServiceExtension.release.xcconfig"; path = "Target Support Files/Pods-OneSignalNotificationServiceExtension/Pods-OneSignalNotificationServiceExtension.release.xcconfig"; sourceTree = "<group>"; };
 		9E719C7B8DD8E912B06801D6 /* Pods_GonativeIO.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GonativeIO.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A02BE0A9266E21BD00B3CF50 /* LEANJsCustomCodeExecutor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LEANJsCustomCodeExecutor.h; sourceTree = "<group>"; };
+		A02BE0AA266E21BD00B3CF50 /* LEANJsCustomCodeExecutor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LEANJsCustomCodeExecutor.m; sourceTree = "<group>"; };
 		AA648B71089D4E82EFE99D9A /* Pods-OneSignalNotificationServiceExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OneSignalNotificationServiceExtension.debug.xcconfig"; path = "Target Support Files/Pods-OneSignalNotificationServiceExtension/Pods-OneSignalNotificationServiceExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		B0DD6F5AF68831471D7D5C41 /* Pods-GonativeIO.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GonativeIO.release.xcconfig"; path = "Target Support Files/Pods-GonativeIO/Pods-GonativeIO.release.xcconfig"; sourceTree = "<group>"; };
 		BB9A3B002631D2A7002C38F1 /* LEANIcons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LEANIcons.swift; sourceTree = "<group>"; };
@@ -487,6 +490,8 @@
 				2002B4A218A9991300495B3D /* Supporting Files */,
 				20C62B7B1D2708B7001D1646 /* GonativeIO-Bridging-Header.h */,
 				BB9A3B002631D2A7002C38F1 /* LEANIcons.swift */,
+				A02BE0A9266E21BD00B3CF50 /* LEANJsCustomCodeExecutor.h */,
+				A02BE0AA266E21BD00B3CF50 /* LEANJsCustomCodeExecutor.m */,
 			);
 			path = LeanIOS;
 			sourceTree = "<group>";
@@ -965,6 +970,7 @@
 				20FC7FB5199D1C7800A70B08 /* LEANTabManager.m in Sources */,
 				209B3219193FA36F0052A7C6 /* LEANUrlCache.m in Sources */,
 				2002B4F918A99C4100495B3D /* LEANMenuViewController.m in Sources */,
+				A02BE0AB266E21BD00B3CF50 /* LEANJsCustomCodeExecutor.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LeanIOS/LEANJsCustomCodeExecutor.h
+++ b/LeanIOS/LEANJsCustomCodeExecutor.h
@@ -1,0 +1,22 @@
+//
+//  LEANJsCustomCodeExecutor.h
+//  GonativeIO
+//
+//  Created by BSC Dev on 07.06.21.
+//  Copyright © 2021 GoNative.io LLC. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol CustomCodeHandler
+- (NSDictionary*)execute:(NSDictionary*)params;
+@end
+
+@interface LEANJsCustomCodeExecutor : NSObject
++ (NSDictionary*)execute:(NSDictionary*)params;
++ (void)setHandler:(NSObject<CustomCodeHandler>*)customHandler;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/LeanIOS/LEANJsCustomCodeExecutor.m
+++ b/LeanIOS/LEANJsCustomCodeExecutor.m
@@ -1,0 +1,58 @@
+//
+//  LEANJsCustomCodeExecutor.m
+//  GonativeIO
+//
+//  Created by BSC Dev on 07.06.21.
+//  Copyright © 2021 GoNative.io LLC. All rights reserved.
+//
+
+#import "LEANJsCustomCodeExecutor.h"
+
+static NSObject<CustomCodeHandler>* _handler = nil;
+
+// The default CustomVCodeHandler "Echo"
+// Simply returns the given NSDictionary
+@interface EchoHandler : NSObject<CustomCodeHandler>
+@end
+
+@implementation EchoHandler
+- (NSDictionary*)execute:(NSDictionary*)params {
+    return params;
+}
+@end
+
+
+@implementation LEANJsCustomCodeExecutor
+
+/**
+ * Sets new CustomCodeHandler to override the default EchoHandler
+ * @param customHandler The new Code Handler
+ */
++ (void)setHandler:(NSObject<CustomCodeHandler>*)customHandler {
+    if(customHandler == nil)
+        return;
+    _handler = customHandler;
+}
+
+/**
+ * Code Handler gets triggered by the LEANWebViewController class
+ * *
+ * @param params An NSDictionary consisting of all URI parameters and their values
+ * @return An NSDictionary as defined by the Code Handler
+ */
++ (NSDictionary*)execute:(NSDictionary*)params {
+    if(_handler == nil) {
+        _handler = [[EchoHandler alloc]init];
+    }
+    
+    @try {
+        return [_handler execute:params];
+    } @catch(NSException *exception) {
+        NSLog(@"%@ %@", @"Error executing custom code", exception.reason);
+    } @finally {
+    }
+    
+    return nil;
+}
+
+@end

--- a/LeanIOS/LEANWebViewController.m
+++ b/LeanIOS/LEANWebViewController.m
@@ -39,6 +39,7 @@
 #import "GNBackgroundAudio.h"
 #import "GonativeIO-Swift.h"
 #import <AppTrackingTransparency/ATTrackingManager.h>
+#import "LEANJsCustomCodeExecutor.h"
 
 #define OFFLINE_URL @"http://offline/"
 
@@ -1131,6 +1132,18 @@
                     if (!u) continue;
                     if (![@"gonative" isEqualToString:u.scheme]) continue;
                     [self shouldLoadRequest:[NSURLRequest requestWithURL:u] isMainFrame:isMainFrame isUserAction:isUserAction hideWebview:hideWebview];
+                }
+            } else if([@"/custom" isEqualToString:url.path]) {
+                NSDictionary *params = [LEANUtilities parseQueryParamsWithUrl:url];
+                
+                // execute code defined by the CustomCodeHandler
+                // call LEANJsCustomCodeExecutor#setHandler to override this default handler
+                NSDictionary *data = [LEANJsCustomCodeExecutor execute:params];
+                
+                NSString *callback = params[@"callback"];
+                if (callback && callback.length > 0) {
+                    NSString *js = [LEANUtilities createJsForCallback:callback data:data];
+                    [self runJavascript:js];
                 }
             }
             return NO;


### PR DESCRIPTION
I've added a section to LEANWebViewController to evaluate our new "custom" path.

When called with no callback function, the code within the currently set CustomCodeHandler gets executed and nothing is reported back. The additional query parameters get passed to the currently set CustomCodeHandler as an NSDictionary to allow further control.

e.g: gonative://nativebridge/custom?dataone=CustomDataString1&datatwo=CustomDataString2

When called with a callback function the behavior is exactly the same except the result the currently set CustomCodeHandler produces is reported back as a new NSDictionary. If no result is produced, the callback function is still called but won't be given any data.

e.g: gonative://nativebridge/custom?callback=customCallbackFunction&dataone=CustomDataString1&datatwo=CustomDataString2

To demonstrate this, the default CustomCodeHandler simply takes all given query parameters and returns them as a NSDictionary.